### PR TITLE
Add census polygons

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2785,8 +2785,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "coa": {
       "version": "2.0.2",
@@ -5049,8 +5048,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5071,14 +5069,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5093,20 +5089,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5223,8 +5216,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5236,7 +5228,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5251,7 +5242,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5259,14 +5249,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5285,7 +5273,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5366,8 +5353,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5379,7 +5365,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5465,8 +5450,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5502,7 +5486,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5522,7 +5505,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5566,14 +5548,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9156,8 +9136,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7006,6 +7006,12 @@
         "object-visit": "^1.0.0"
       }
     },
+    "material-design-icons-iconfont": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-4.0.5.tgz",
+      "integrity": "sha512-ByJJ1yz8+RfCx2uNiC5WjVCR7K3UWRb8ytWV3RMaoFRzQLNr/J5x7+Wg1+3OlIZahNXrId9Hu+BfXfQIo01v7g==",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0",
+    "material-design-icons-iconfont": "^4.0.5",
     "vue-template-compiler": "^2.5.21"
   },
   "eslintConfig": {

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -154,7 +154,6 @@ export default {
       return markersArray;
     },
     createCensusTractContent(props) {
-      console.log(props);
       const propertyString = 
       `<span class="pdx-tooltip__title">${props.county_1} County, ${props.state_1}</span><br>
       <strong>CENSUS TRACT:</strong> ${props.censustrac} 

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -1,6 +1,26 @@
 <template>
   <v-layout>
     <v-flex>
+      <div style="height: 10%; overflow: auto;">
+        <span v-if="loading">Map Layers Loading... </span>
+        <label for="checkbox">GeoJSON Visibility </label>
+        <input
+          id="checkbox"
+          v-model="show"
+          type="checkbox"
+        >
+        <label for="checkboxTooltip">Enable tooltip </label>
+        <input
+          id="checkboxTooltip"
+          v-model="enableTooltip"
+          type="checkbox"
+        >
+        <input
+          v-model="fillColor"
+          type="color"
+        >
+        <br>
+      </div>
       <l-map
         ref="map"
         style="height: 700px; width: 100%"
@@ -28,7 +48,12 @@
             </div>
           </l-popup>
         </l-marker>
-        <l-geo-json :geojson="pdxTractGeoJSON">
+        <l-geo-json
+          v-if="show"
+          :geojson="pdxTractGeoJSON"
+          :options="options"
+          :options-style="styleFunction"
+        >
         </l-geo-json>
       </l-map>
     </v-flex>
@@ -50,6 +75,32 @@ export default {
         return mapMarkers;
       }
       return mapMarkers;
+    },
+    options() {
+      return {
+        onEachFeature: this.onEachFeatureFunction
+      };
+    },
+    styleFunction() {
+      // important! need fillColor in computed for re-calculation when changing fillColor
+      const fillColor = this.fillColor;
+      return () => {
+        return {
+          weight: 1,
+          color: '#A9A9A9',
+          opacity: 1,
+          fillColor: fillColor,
+          fillOpacity: .1
+        };
+      };
+    },
+    onEachFeatureFunction() {
+      if (!this.enableTooltip) {
+        return () => { };
+      }
+      return (feature, layer) => {
+        layer.bindTooltip("I am a tooltip", { permanent: false, sticky: true });
+      };
     }
   },
   data() {
@@ -60,7 +111,10 @@ export default {
       bounds: null,
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
       subdomains: 'abcd',
-      maxZoom: 18
+      maxZoom: 18,
+      fillColor: '#e4ce7f',
+      enableTooltip: false,
+      show: false
     };
   },
   methods: {
@@ -85,5 +139,11 @@ export default {
       return markersArray;
     },
   },
+  props: {
+    loading: Boolean,
+    default: function () {
+      return false;
+    },
+  }
 }
 </script>

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -37,22 +37,21 @@
         </l-geo-json>
         <l-control position="topleft">
           <div v-if="loading">
-            <v-card style="padding: 15px;">
+            <v-card class="pdx-leafletControl__card">
               <v-progress-circular indeterminate rotate color="accent"></v-progress-circular>
               Loading Census Tract Layer... 
             </v-card>
           </div>
         </l-control>
         <l-control position="bottomleft">
-          <v-card style="padding: 15px;">
-              
-                <v-checkbox
-                v-model="show"
-                :label="`Census Tracts`"></v-checkbox>
-                 <v-checkbox
-                  v-model="enableTooltip"
-                  :label="`Census Tract Tooltips`"
-                ></v-checkbox>
+          <v-card class="pdx-leafletControl__card">    
+            <v-checkbox
+            v-model="show"
+            :label="`Census Tracts`"></v-checkbox>
+              <v-checkbox
+            v-model="enableTooltip"
+            :label="`Census Tract Tooltips`"
+            ></v-checkbox>
           </v-card>
         </l-control>
       </l-map>
@@ -111,9 +110,9 @@ export default {
       return (feature, layer) => {
         const tooltipContent = this.createCensusTractContent(feature.properties);
         layer.bindTooltip(tooltipContent, { permanent: false, sticky: true, className: 'pdx-tooltip' });
-        layer.on("mouseover", (e) => {
+        layer.on("mouseover", () => {
         layer.setStyle(highlightStyle);
-        layer.on("mouseout", (e) => {
+        layer.on("mouseout", () => {
           layer.setStyle(defaultStyle);
         });
       });
@@ -184,6 +183,10 @@ export default {
   margin: 0 !important;
   padding: 0 !important;
 }
+
+.pdx-leafletControl__card {
+  padding: 15px;
+}
 .pdx-tooltip {
   text-align: left;
 }
@@ -191,7 +194,6 @@ export default {
   font-weight: bold;
   text-align: center;
   text-transform: uppercase;
-  
 }
 </style>
 

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -28,6 +28,8 @@
             </div>
           </l-popup>
         </l-marker>
+        <l-geo-json :geojson="pdxTractGeoJSON">
+        </l-geo-json>
       </l-map>
     </v-flex>
   </v-layout>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -9,15 +9,17 @@ import colors from "vuetify/es5/util/colors";
 import "../node_modules/leaflet/dist/leaflet.css";
 import L from "leaflet";
 delete L.Icon.Default.prototype._getIconUrl;
+import 'material-design-icons-iconfont/dist/material-design-icons.css';
 
 // register Vue2Leaflet components
-import { LMap, LTileLayer, LMarker, LPopup, LGeoJson } from "vue2-leaflet";
+import { LMap, LTileLayer, LMarker, LPopup, LGeoJson, LControl } from "vue2-leaflet";
 
 Vue.component("l-map", LMap);
 Vue.component("l-tile-layer", LTileLayer);
 Vue.component("l-marker", LMarker);
 Vue.component("l-popup", LPopup);
 Vue.component("l-geo-json", LGeoJson);
+Vue.component("l-control", LControl);
 
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),
@@ -29,6 +31,7 @@ Vue.config.productionTip = false;
 
 Vue.use(L);
 Vue.use(Vuetify, {
+  iconfont: 'md',
   theme: {
     primary: colors.green,
     secondary: colors.lightGreen,

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -11,12 +11,13 @@ import L from "leaflet";
 delete L.Icon.Default.prototype._getIconUrl;
 
 // register Vue2Leaflet components
-import { LMap, LTileLayer, LMarker, LPopup } from "vue2-leaflet";
+import { LMap, LTileLayer, LMarker, LPopup, LGeoJson } from "vue2-leaflet";
 
 Vue.component("l-map", LMap);
 Vue.component("l-tile-layer", LTileLayer);
 Vue.component("l-marker", LMarker);
 Vue.component("l-popup", LPopup);
+Vue.component("l-geo-json", LGeoJson);
 
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),

--- a/client/src/store/pdxTract.js
+++ b/client/src/store/pdxTract.js
@@ -22,7 +22,7 @@ const mutations = {
 
 const state = {
   pdxTractList: [],
-  pdxTractGeoJSON: {}
+  pdxTractGeoJSON: null
 };
 
 const getters = {};

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -14,9 +14,8 @@ export default {
     MainMap
   },
   async created() {
-
     await this.$store.dispatch("groceryStore/getGroceryStoreGeoJSON");
-    this.$store.dispatch("pdxTract/getPdxTractGeoJSON");
+    await this.$store.dispatch("pdxTract/getPdxTractGeoJSON");
   },
 }
 </script>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div style="height: 95vh; width: 100%">
-    <main-map></main-map>
+    <main-map :loading="loading"></main-map>
   </div>
 </template>
 
@@ -14,8 +14,15 @@ export default {
     MainMap
   },
   async created() {
+    this.loading = true;
     await this.$store.dispatch("groceryStore/getGroceryStoreGeoJSON");
     await this.$store.dispatch("pdxTract/getPdxTractGeoJSON");
+    this.loading = false;
+  },
+  data() {
+    return {
+      loading: false
+    }
   },
 }
 </script>

--- a/cypress/integration/groceryStoreMarkers_spec.js
+++ b/cypress/integration/groceryStoreMarkers_spec.js
@@ -1,5 +1,6 @@
 describe("Example", () => {
   const markersArray = ".leaflet-marker-pane img";
+  const popupContent = ".leaflet-popup-content";
 
   beforeEach(() => {
     cy.visit("/");
@@ -10,11 +11,7 @@ describe("Example", () => {
     cy.get(markersArray)
       .first()
       .click();
-    cy.contains("Green Zebra Grocery").should("be.visible");
-    cy.get(markersArray)
-      .eq(10)
-      .click();
-    cy.contains("People's Food Coop").should("be.visible");
-    cy.contains("Green Zebra Grocery").should("not.be.visible");
+      cy.wait(1000);
+    cy.get(popupContent).should("contain", "Green Zebra Grocery");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-leaflet-express-boilerplate",
+  "name": "pdx-food-map",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Fixes #9 

First pass as lightly styled census polygons which display data on hover. (Need an alternative display to make it accessible and a lot more work on the data viz and interactions in general, but it's a good first pass at wiring up the data to the front end.)