### PR TITLE
Add grocery store filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ const expressOpenapi = require("express-openapi");
 const path = require("path");
 const pkg = require("./package");
 
-const ExampleService = require("./lib/exampleService");
 const FarmersMarketService = require("./lib/farmersMarketService");
 const GroceryStoreService = require("./lib/groceryStoreService");
 const PdxTractService = require("./lib/pdxTractService");
@@ -25,7 +24,6 @@ process.env.TZ = "UTC";
       config: config.get("pg")
     });
 
-    const exampleService = new ExampleService({ pg });
     const farmersMarketService = new FarmersMarketService({ pg });
     const groceryStoreService = new GroceryStoreService({ pg });
     const pdxTractService = new PdxTractService({ pg });
@@ -111,7 +109,6 @@ process.env.TZ = "UTC";
       },
       dependencies: {
         env,
-        exampleService,
         farmersMarketService,
         groceryStoreService,
         pdxTractService,

--- a/client/src/api/groceryStore.js
+++ b/client/src/api/groceryStore.js
@@ -19,6 +19,13 @@ export default {
       url: `/api/groceryStoreGeoJSON`
     });
   },
+  getGeoDataByType(params) {
+    return axios({
+      data: params,
+      method: "post",
+      url: `/api/groceryStore/getGeoDataByType`
+    });
+  },
   search(params) {
     return axios({
       data: params,

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -180,18 +180,21 @@
                 label="All"
                 value="all"
                 class="pdx-layerControls--radioButtons"
+                data-cy="radioButton--allStores"
               ></v-radio>
               <v-radio
                 color="accent"
                 label="Large Chain"
                 value="Large Chain Grocery"
                 class="pdx-layerControls--radioButtons"
+                data-cy="radioButton--largeChain"
               ></v-radio>
               <v-radio
                 color="accent"
                 label="Independent or Ethnic"
                 value="Independent or Ethnic Grocery"
                 class="pdx-layerControls--radioButtons"
+                data-cy="radioButton--independent"
               ></v-radio>
 
             </v-radio-group>

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -28,7 +28,7 @@
         >
           <v-radio-group
             class="pa-0 ma-0"
-            v-model="radios"
+            v-model="radiosDistance"
             row
             label="search radius"
           >
@@ -164,6 +164,32 @@
               :label="`Grocery Stores`"
               data-cy="checkbox--groceryStores"
             ></v-checkbox>
+            <v-radio-group
+              dense
+              small
+              v-if="showGroceryStores"
+              v-model="radiosStoreType"
+              label="Filter by Store Type"
+              class="pt-0, mt-0"
+              @change="filterStores"
+            >
+              <v-radio
+                color="accent"
+                label="All"
+                value="all"
+              ></v-radio>
+              <v-radio
+                color="accent"
+                label="Large Chain"
+                value="Large Chain Grocery"
+              ></v-radio>
+              <v-radio
+                color="accent"
+                label="Independent or Ethnic"
+                value="Independent or Ethnic Grocery"
+              ></v-radio>
+
+            </v-radio-group>
             <v-checkbox
               v-model="showFarmersMarkets"
               :label="`Farmers Markets`"
@@ -400,9 +426,9 @@ export default {
       };
     },
     searchDistance() {
-      if (this.radios == "radio-half") {
+      if (this.radiosDistance == "radio-half") {
         return "1/2 mile";
-      } else if (this.radios == "radio-1") {
+      } else if (this.radiosDistance == "radio-1") {
         return "1 mile";
       }
       return "";
@@ -423,7 +449,8 @@ export default {
       showGroceryStores: false,
       showMapControls: true,
       showSearchResults: false,
-      radios: "radio-1",
+      radiosDistance: "radio-1",
+      radiosStoreType: "all",
       // eslint-disable-next-line
       farmersMarketIcon: L.icon({
         iconUrl: 'leaflet/PDXFoodMap631.svg',
@@ -480,7 +507,7 @@ export default {
         const geom = `${x}, ${y}`;
         // default distance = 1 mile = 1609.34 meters
         let distance = 1609.34;
-        if (this.radios === "radio-half") {
+        if (this.radiosDistance === "radio-half") {
           distance = 804.672;
         }
 
@@ -556,6 +583,14 @@ export default {
       }
 
       return propertyString;
+    },
+    async filterStores(value) {
+      if (value == 'all') {
+        await this.$store.dispatch("groceryStore/getGroceryStoreGeoJSON");
+      } else {
+        const params = { type: value };
+        await this.$store.dispatch("groceryStore/getGroceryStoreGeoJSON", params);
+      }
     },
     formatCurrency(dollarValue) {
       // syntax numObj.toLocaleString([locales [, options]])

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -152,41 +152,46 @@
               v-model="showCensusTracts"
               :label="`Census Tracts`"
               data-cy="checkbox--censusTracts"
+              class="pdx-layerControls"
             ></v-checkbox>
             <v-checkbox
               v-if="showCensusTracts"
               v-model="enableTooltip"
               :label="`Census Tract Tooltips`"
               data-cy="checkbox--tooltips"
+              class="pdx-layerControls"
             ></v-checkbox>
             <v-checkbox
               v-model="showGroceryStores"
               :label="`Grocery Stores`"
               data-cy="checkbox--groceryStores"
+              class="pdx-layerControls"
             ></v-checkbox>
             <v-radio-group
-              dense
-              small
               v-if="showGroceryStores"
               v-model="radiosStoreType"
               label="Filter by Store Type"
-              class="pt-0, mt-0"
+              class="pa-0"
+              style="margin: 0 0 -15px 32px;"
               @change="filterStores"
             >
               <v-radio
                 color="accent"
                 label="All"
                 value="all"
+                class="pdx-layerControls--radioButtons"
               ></v-radio>
               <v-radio
                 color="accent"
                 label="Large Chain"
                 value="Large Chain Grocery"
+                class="pdx-layerControls--radioButtons"
               ></v-radio>
               <v-radio
                 color="accent"
                 label="Independent or Ethnic"
                 value="Independent or Ethnic Grocery"
+                class="pdx-layerControls--radioButtons"
               ></v-radio>
 
             </v-radio-group>
@@ -194,18 +199,21 @@
               v-model="showFarmersMarkets"
               :label="`Farmers Markets`"
               data-cy="checkbox--farmersMarkets"
+              class="pdx-layerControls"
             ></v-checkbox>
+            <br>
             <div>MAP LEGEND</div>
             <v-divider class="py-2"></v-divider>
             <v-layout
               align-start
               justify-start
-              column
+              row
               fill-height
             >
               <v-flex>
                 <v-layout
                   align-center
+                  justify-start
                   class="text-xs-left"
                 >
                   <img
@@ -216,27 +224,29 @@
                 </v-layout>
               </v-flex>
               <v-flex>
-                <v-layout align-center>
+                <v-layout
+                  align-center
+                  justify-start
+                  class="text-xs-left"
+                >
                   <img
                     src="leaflet/PDXFoodMap631.svg"
                     alt="farmers market symbol"
                   >
                   <div>Farmers Markets</div>
-
                 </v-layout>
               </v-flex>
-              <v-flex>
-                <v-layout align-center>
-                  <div class="pdx-legendSymbol--foodDesert"></div>
-                  <div>Food Desert</div>
-                </v-layout>
-                <v-layout align-center>
-                  <div class="pdx-legendSymbol--lowVehicle"></div>
-                  <div>Low Vehicle Access</div>
-                </v-layout>
-              </v-flex>
-
             </v-layout>
+            <v-flex>
+              <v-layout align-center>
+                <div class="pdx-legendSymbol--foodDesert"></div>
+                <div>Food Desert</div>
+              </v-layout>
+              <v-layout align-center>
+                <div class="pdx-legendSymbol--lowVehicle"></div>
+                <div>Low Vehicle Access</div>
+              </v-layout>
+            </v-flex>
             <v-flex
               mt-2
               class="text-xs-left"
@@ -680,6 +690,15 @@ export default {
   top: 155px;
   width: 360px;
   z-index: 10000;
+}
+
+.pdx-layerControls {
+  height: 30px !important;
+}
+
+.pdx-layerControls--radioButtons {
+  height: 20px !important;
+  padding: 0;
 }
 
 .pdx-leafletControl__card {

--- a/client/src/store/groceryStore.js
+++ b/client/src/store/groceryStore.js
@@ -5,8 +5,13 @@ const actions = {
     const groceryStoreList = await groceryStoreApi.list();
     return commit("setList", groceryStoreList.data);
   },
-  async getGroceryStoreGeoJSON({ commit }) {
-    const groceryStoreGeoJSON = await groceryStoreApi.getGeoJSON();
+  async getGroceryStoreGeoJSON({ commit }, params) {
+    let groceryStoreGeoJSON;
+    if (params) {
+      groceryStoreGeoJSON = await groceryStoreApi.getGeoDataByType(params);
+    } else {
+      groceryStoreGeoJSON = await groceryStoreApi.getGeoJSON();
+    }
     return commit("setGeoJSON", groceryStoreGeoJSON.data);
   },
   async search({ commit }, params) {

--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,5 @@
   "pageLoadTimeout": 100000,
   "requestTimeout": 60000,
   "responseTimeout": 50000,
-  "video": false
+  "video": true
 }

--- a/cypress/integration/map_spec.js
+++ b/cypress/integration/map_spec.js
@@ -6,6 +6,10 @@ describe("Map Controls", () => {
     "div[data-cy=checkbox--censusTracts] > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple";
   const groceryStoreCheckbox =
     "div[data-cy=checkbox--groceryStores] > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple";
+  const groceryStoreFilterAll = "[data-cy=radioButton--allStores]";
+  const groceryStoreFilterLargeChain = "[data-cy=radioButton--largeChain]";
+  const groceryStoreFilterIndependent = "[data-cy=radioButton--independent]";
+
   const farmersMarketCheckbox =
     "div[data-cy=checkbox--farmersMarkets] > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple";
   const tooltipsCheckbox =
@@ -21,7 +25,7 @@ describe("Map Controls", () => {
     cy.visit("/");
   });
 
-  it.only("Toggles map layers", () => {
+  it("Toggles map layers", () => {
     cy.get(welcomeWindowCloseButton).click();
     cy.wait(7000);
     cy.get(groceryStoreCheckbox).click();
@@ -51,9 +55,25 @@ describe("Map Controls", () => {
     cy.get('[data-key="0"]').click();
     cy.wait(2000);
     cy.contains("SEARCH RESULTS").should("be.visible");
-    cy.contains("Grocery stores within 1 mile: 4").should("be.visible");
-    cy.contains("Farmers markets within 1 mile: 3").should("be.visible");
+    cy.contains("Grocery Stores: 4").should("be.visible");
+    cy.contains("Farmers Markets: 3").should("be.visible");
     cy.get(clearResultsButton).click();
     cy.contains("SEARCH RESULTS").should("not.be.visible");
+  });
+
+  it("Filters grocery store layer by store type", () => {
+    cy.get(welcomeWindowCloseButton).click();
+    cy.wait(7000);
+    cy.get(groceryStoreCheckbox).click();
+    cy.wait(1000);
+    cy.get(groceryStoreFilterLargeChain).click({ force: true });
+    cy.wait(1000);
+    cy.get(groceryStoreMarkers).should("have.length", 205);
+    cy.get(groceryStoreFilterIndependent).click({ force: true });
+    cy.wait(1000);
+    cy.get(groceryStoreMarkers).should("have.length", 59);
+    cy.get(groceryStoreFilterAll).click({ force: true });
+    cy.wait(1000);
+    cy.get(groceryStoreMarkers).should("have.length", 264);
   });
 });

--- a/lib/groceryStoreService.js
+++ b/lib/groceryStoreService.js
@@ -3,6 +3,7 @@ let table = "grocery_stores";
 function factory({ pg }) {
   return {
     get,
+    getGeoDataByType,
     getGeoJSON,
     list,
     search
@@ -38,6 +39,29 @@ FROM (
     'properties', to_jsonb(row) - 'gid' - 'geom'
   ) AS feature
   FROM (SELECT * FROM ${table}) row WHERE status='Existing') features;
+    `;
+
+    const result = await pg.query(query);
+    return result[0]["jsonb_build_object"];
+  }
+
+  async function getGeoDataByType(searchParams) {
+    console.log("search params", searchParams);
+    const { type } = searchParams;
+    // prettier-ignore
+    const query =
+  `SELECT jsonb_build_object(
+    'type',     'FeatureCollection',
+    'features', jsonb_agg(feature)
+)
+FROM (
+  SELECT jsonb_build_object(
+    'type',       'Feature',
+    'id',         gid,
+    'geometry',   ST_AsGeoJSON(geom)::jsonb,
+    'properties', to_jsonb(row) - 'gid' - 'geom'
+  ) AS feature
+  FROM (SELECT * FROM ${table}) row WHERE status='Existing' AND type='${type}') features;
     `;
 
     const result = await pg.query(query);

--- a/routes/groceryStore/getGeoDataByType.js
+++ b/routes/groceryStore/getGeoDataByType.js
@@ -1,0 +1,58 @@
+function factory(logger, groceryStoreService) {
+  POST.apiDoc = {
+    summary:
+      "Returns a GeoJSON Feature Collection (Grocery Stores in the PDX-Vancouver-Hillsboro MSA by store type)",
+    tags: ["PDX Metro Grocery Stores"],
+    produces: ["application/json"],
+    parameters: [
+      {
+        description: "Search terms",
+        in: "body",
+        name: "search",
+        required: true,
+        schema: {
+          properties: {
+            type: {
+              description: "Type of grocery store",
+              type: "string"
+            }
+          },
+          type: "object"
+        }
+      }
+    ],
+    responses: {
+      200: {
+        description: "OK"
+      },
+      500: {
+        description: "Server Error"
+      }
+    }
+  };
+
+  return {
+    POST
+  };
+
+  async function POST(req, res) {
+    const { body } = req;
+    console.log("POST BODY", body);
+
+    let result;
+    try {
+      result = await groceryStoreService.getGeoDataByType(body);
+    } catch (e) {
+      logger.error(e);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+
+    if (!result) {
+      result = [];
+    }
+
+    return res.status(200).json(result);
+  }
+}
+
+module.exports = factory;


### PR DESCRIPTION
With this change, users will be allowed to filter grocery store point features by grocery store type (`Large Chain Grocery` or `Independent or Ethnic Grocery`).  
Also cleans up some example code I missed in my last PR.