### PR TITLE
Disable map drag when using map controls

### DIFF
--- a/client/src/components/CensusTractProfile.vue
+++ b/client/src/components/CensusTractProfile.vue
@@ -23,9 +23,10 @@
       </div>
     </div>
     <div v-else>
-      <div class="title">Portland-Vancouver-Hillsboro Metropolitan Statistical Area</div>
+      <div class="title text-center">Portland-Vancouver-Hillsboro Metropolitan Statistical Area</div>
       <v-divider class="my-2"></v-divider>
-      <div>Click on a census tract!</div>
+
+      <div>Click on a census tract to learn more about its food environment.</div>
     </div>
   </div>
 </template>

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -702,7 +702,7 @@ export default {
           } = e;
           this.setTract(properties);
           this.setSelectedTab("map");
-          this.$refs.map.fitBounds(tractBounds);
+          // this.$refs.map.fitBounds(tractBounds);
           this.setDisplayAllPointLayers(true);
         });
         if (tooltipDisplay) {
@@ -788,8 +788,11 @@ export default {
       });
     },
     resetMapView() {
+      this.setDisplayAllPointLayers(false);
+      this.setDisplayAllLineLayers(false);
       this.setCenter(this.defaultCenter);
       this.setZoom(this.defaultZoom);
+      this.setTract({});
     },
     async searchForPoints(geosearchResult) {
       const x = geosearchResult.location.x;
@@ -861,10 +864,17 @@ export default {
       this.setDisplayStatusFoodPantry(val);
       this.setDisplayStatusTrimetStop(val);
     },
+    setDisplayAllLineLayers(val) {
+      this.setDisplayStatusBikePathPortland(val);
+      this.setDisplayStatusCtranRoute(val);
+      this.setDisplayStatusTrailClarkCounty(val);
+      this.setDisplayStatusTrimetRoute(val);
+    },
     zoomUpdated(zoom) {
       this.setZoom(zoom);
     },
     ...mapMutations({
+      setDisplayStatusBikePathPortland: "bikePathPortland/setDisplayStatus",
       setDisplayStatusCsaDropoffSite: "csaDropoffSite/setDisplayStatus",
       setDisplayStatusCtranRoute: "ctranRoute/setDisplayStatus",
       setDisplayStatusCtranStop: "ctranStop/setDisplayStatus",

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -18,11 +18,11 @@
             <v-icon color="primary">home</v-icon>
           </v-btn>
         </l-control>
-        <l-control position="topright">
+        <l-control position="topright" ref="mapLayerControl">
           <MapLayers />
         </l-control>
         <v-geosearch :options="geosearchOptions" ref="geosearch"></v-geosearch>
-        <l-control position="topleft">
+        <l-control position="topleft" ref="mapControl">
           <MapControls />
         </l-control>
         <l-control-scale position="bottomleft"></l-control-scale>
@@ -673,10 +673,22 @@ export default {
         this.setGeosearchResult(null);
       });
 
-      this.$refs.map.mapObject.on("zoomend", () => {
-        if (this.$refs.map.mapObject.getZoom() < 8) {
-          this.setDisplayAllPointLayers(false);
-        }
+      const mapControl = L.DomUtil.get(this.$refs.mapControl.mapObject.element);
+      mapControl.addEventListener("mouseover", () => {
+        this.$refs.map.mapObject.dragging.disable();
+      });
+      mapControl.addEventListener("mouseout", () => {
+        this.$refs.map.mapObject.dragging.enable();
+      });
+
+      const mapLayerControl = L.DomUtil.get(
+        this.$refs.mapLayerControl.mapObject.element
+      );
+      mapLayerControl.addEventListener("mouseover", () => {
+        this.$refs.map.mapObject.dragging.disable();
+      });
+      mapLayerControl.addEventListener("mouseout", () => {
+        this.$refs.map.mapObject.dragging.enable();
       });
     });
   },

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -365,7 +365,6 @@
 </template>
 
 <script>
-// TODO: Constrain zoom out
 import { mapMutations, mapState } from "vuex";
 import { OpenStreetMapProvider } from "leaflet-geosearch";
 import MapControls from "@/components/MapControls.vue";
@@ -824,7 +823,7 @@ export default {
       }
     },
     setDefaultTractStyles(layer, feature) {
-      // TODO: double-check measurment fo lilatrac_1 (1/2mi or 1mi?)
+      // TODO: double-check measurement fo lilatrac_1 (1/2mi or 1mi?)
       layer.setStyle(tractDefaultStyle);
       if (feature.properties.lilatrac_1 == 1) {
         layer.setStyle(foodDesertDefaultStyle);

--- a/client/src/components/MapControls.vue
+++ b/client/src/components/MapControls.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="mt-10">
-    <v-navigation-drawer v-model="drawer" :mini-variant.sync="mini" width="340">
+    <v-navigation-drawer v-model="drawer" :mini-variant.sync="mini" width="340" permanent>
       <template v-slot:prepend>
         <v-list-item v-if="mini" dense>
           <v-btn small icon @click.stop="mini = false">
@@ -60,6 +60,7 @@ export default {
         return this.$store.state.map.mapControlMini;
       },
       set(value) {
+        console.log("setting value of mini");
         this.setMapControlMini(value);
       },
     },

--- a/client/src/store/map.js
+++ b/client/src/store/map.js
@@ -34,7 +34,7 @@ const mutations = {
 
 const state = {
   center: [45.59, -122.6793],
-  displayStatusTooltip: true,
+  displayStatusTooltip: false,
   geosearchResult: null,
   userLatitude: null,
   userLongitude: null,


### PR DESCRIPTION
The map was dragging when interacting with the map controls. 

I added event listeners to the the map controls that disable and re-enable dragging on `mouseover` and  `mouseout`, respectively. 

I also fixed the issue where the census tract/search map control would become blank on small screens. (The navigation drawer needed to have the `permanent` attribute.)

