### PR TITLE
Styling and UX improvements based on UAT feedback

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -125,6 +125,10 @@ li {
   opacity: 0.8;
 }
 
+.leaflet-container {
+  font-size: 0.95rem !important;
+}
+
 .pdx-toolbar--main {
   font-weight: bold;
 }

--- a/client/src/components/CensusTractProfile.vue
+++ b/client/src/components/CensusTractProfile.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <div v-if="tract.gid" class="text-center">
-      <div class="title secondary--text">Census Tract No. {{tract.censustrac}}</div>
-      <div class="subtitle-1 display-3 primary--text">{{tract.county_1}} County, {{tract.state_1}}</div>
+      <h1 class="secondary--text">Census Tract No. {{tract.censustrac}}</h1>
+      <div class="primary--text">{{tract.county_1}} County, {{tract.state_1}}</div>
       <v-divider class="my-2"></v-divider>
-      <div class="body-1">
+      <div>
         <div class="my-5">
           <div class="font-weight-black display-1 primary--text">{{tract.povertyrat}}%</div>
-          <div class="font-weight-thin">Poverty Rate</div>
+          <div class="font-weight-thin primary--text">Poverty Rate</div>
         </div>
         <div class="my-5">
           <div
@@ -23,10 +23,10 @@
         </div>
       </div>
       <div v-if="tract.lilatrac_1">
-        <span class="font-weight-black primary--text title">FOOD DESERT</span>
+        <span class="font-weight-black tertiary--text title">FOOD DESERT</span>
       </div>
       <div v-if="tract.hunvflag">
-        <span class="font-weight-bold primary-text title">LOW VEHICLE ACCESS</span>
+        <span class="font-weight-bold tertiary--text title">LOW VEHICLE ACCESS</span>
       </div>
       <div>
         <v-btn color="secondary" small rounded outlined class="mt-4" @click="clearSelectedTract">
@@ -41,7 +41,7 @@
       </h1>
       <v-divider class="my-2"></v-divider>
 
-      <div class="body-2 primary--text">
+      <div class="primary--text">
         Click on a census tract to learn more about food access indicators in the Portland Metro area.
         <v-flex class="ma-5">
           <v-layout align-center>

--- a/client/src/components/CensusTractProfile.vue
+++ b/client/src/components/CensusTractProfile.vue
@@ -35,36 +35,32 @@
       </div>
     </div>
     <div v-else>
-      <h1 class="text-center">Portland-Vancouver-Hillsboro Metropolitan Statistical Area</h1>
+      <h1 class="text-center secondary--text">
+        Portland-Vancouver-Hillsboro
+        <br />Metropolitan Statistical Area
+      </h1>
       <v-divider class="my-2"></v-divider>
 
-      <div>
-        Zoom to any track by clicking on it and discover more about the tract's food environment.
-        <v-flex>
+      <div class="body-2 primary--text">
+        Click on a census tract to learn more about food access indicators in the Portland Metro area.
+        <v-flex class="ma-5">
           <v-layout align-center>
             <div class="pdx-legendSymbol--foodDesert"></div>
-            <div>Food Desert</div>
+            <div class="font-weight-bold">Food Desert</div>
           </v-layout>
+          <div class="my-2">
+            More than 20%
+            of households are low-income AND at least 33% live more than 1/2
+            mile from the nearest supermarket.
+          </div>
           <v-layout align-center>
             <div class="pdx-legendSymbol--lowVehicle"></div>
-            <div>Low Vehicle Access</div>
+            <div class="font-weight-bold">Low Vehicle Access</div>
           </v-layout>
-        </v-flex>
-        <v-flex mt-2 class="text-xs-left">
-          <div>
-            <Strong>Food Desert</Strong>: a census tract where more than 20%
-            of households are low-income AND at least 33% live more than 1/2
-            mile (urban areas) or more than 10 miles (rural areas) from the
-            nearest supermarket.
-          </div>
           <div class="mt-2">
-            <strong>Low Vehicle Access</strong>: a census tract where at
-            least 100 households are more than ½ mile from the nearest
-            supermarket and have no access to a vehicle;
-            <em>or</em>, at
-            least 500 people or 33 percent of the population live more than
-            20 miles from the nearest supermarket, regardless of vehicle
-            access.
+            At least 100 households
+            are more than ½ mile from the nearest
+            supermarket and have no access to a vehicle.
           </div>
         </v-flex>
       </div>

--- a/client/src/components/CensusTractProfile.vue
+++ b/client/src/components/CensusTractProfile.vue
@@ -29,7 +29,7 @@
         <span class="font-weight-bold tertiary--text title">LOW VEHICLE ACCESS</span>
       </div>
       <div>
-        <v-btn color="secondary" small rounded outlined class="mt-4" @click="clearSelectedTract">
+        <v-btn color="secondary" small text class="mt-4" @click="clearSelectedTract">
           <v-icon class="mr-1">close</v-icon>Clear Tract Selection
         </v-btn>
       </div>

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -387,7 +387,7 @@ export default {
     csaDropoffSiteMarkers() {
       const geojson = this.$store.state.csaDropoffSite.geoJSON;
       let mapMarkers = [];
-      const icon = this.zoom > 12 ? this.csaIcon : this.csaIconSmall;
+      const icon = this.csaIcon;
       if (geojson.features) {
         mapMarkers = this.createMarkers(geojson, icon);
         return mapMarkers;
@@ -397,8 +397,7 @@ export default {
     groceryStoreMarkers() {
       const geojson = this.$store.state.groceryStore.geoJSON;
       let mapMarkers = [];
-      const icon =
-        this.zoom > 12 ? this.groceryStoreIcon : this.groceryStoreIconSmall;
+      const icon = this.groceryStoreIcon;
       if (geojson.features) {
         mapMarkers = this.createMarkers(geojson, icon);
         return mapMarkers;
@@ -408,7 +407,7 @@ export default {
     foodPantryMarkers() {
       const geojson = this.$store.state.foodPantry.geoJSON;
       let mapMarkers = [];
-      const icon = this.zoom > 12 ? this.pantryIcon : this.pantryIconSmall;
+      const icon = this.pantryIcon;
       if (geojson.features) {
         mapMarkers = this.createMarkers(geojson, icon);
         return mapMarkers;
@@ -418,8 +417,7 @@ export default {
     farmersMarketMarkers() {
       const geojson = this.$store.state.farmersMarket.geoJSON;
       let mapMarkers = [];
-      const icon =
-        this.zoom > 12 ? this.farmersMarketIcon : this.farmersMarketIconSmall;
+      const icon = this.farmersMarketIcon;
       if (geojson.features) {
         mapMarkers = this.createMarkers(geojson, icon);
         return mapMarkers;
@@ -580,23 +578,9 @@ export default {
         popupAnchor: [-4, -20],
       }),
       // eslint-disable-next-line
-      csaIconSmall: L.icon({
-        iconUrl: "leaflet/map_marker_csa.svg",
-        iconSize: [20, 20],
-        iconAnchor: [20, 20],
-        popupAnchor: [-4, -20],
-      }),
-      // eslint-disable-next-line
       farmersMarketIcon: L.icon({
         iconUrl: "leaflet/map_marker_market.svg",
         iconSize: [30, 30],
-        iconAnchor: [20, 20],
-        popupAnchor: [-4, -20],
-      }),
-      // eslint-disable-next-line
-      farmersMarketIconSmall: L.icon({
-        iconUrl: "leaflet/map_marker_market.svg",
-        iconSize: [20, 20],
         iconAnchor: [20, 20],
         popupAnchor: [-4, -20],
       }),
@@ -608,25 +592,11 @@ export default {
         popupAnchor: [-4, -20],
       }),
       // eslint-disable-next-line
-      groceryStoreIconSmall: L.icon({
-        iconUrl: "leaflet/map_marker_store.svg",
-        iconSize: [20, 20],
-        iconAnchor: [20, 20],
-        popupAnchor: [-4, -20],
-      }),
-      // eslint-disable-next-line
       pantryIcon: L.icon({
         iconUrl: "leaflet/map_marker_pantry.svg",
         iconSize: [30, 30],
         iconAnchor: [25, 50],
         popupAnchor: [-10, -50],
-      }),
-      // eslint-disable-next-line
-      pantryIconSmall: L.icon({
-        iconUrl: "leaflet/map_marker_pantry.svg",
-        iconSize: [20, 20],
-        iconAnchor: [20, 20],
-        popupAnchor: [0, -24],
       }),
       // eslint-disable-next-line
       geosearchIcon: L.icon({

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -90,10 +90,10 @@
                   {{ item.props.accepts }}
                 </div>
                 <div v-if="item.props.website" class="my-1">
-                  <a
-                    :href="item.props.website"
-                    class="secondary--text font-weight-bold"
-                  >>>> Visit Website</a>
+                  <a :href="item.props.website" class="secondary--text font-weight-bold">
+                    >>> Visit Website
+                    <v-icon small color="secondary">launch</v-icon>
+                  </a>
                 </div>
               </div>
             </l-popup>
@@ -143,10 +143,10 @@
                   {{ item.props.snap }}
                 </div>
                 <div v-if="item.props.website" class="mt-1">
-                  <a
-                    :href="item.props.website"
-                    class="secondary--text font-weight-bold"
-                  >>>> Visit Website</a>
+                  <a :href="item.props.website" class="secondary--text font-weight-bold">
+                    >>> Visit Website
+                    <v-icon small color="secondary">launch</v-icon>
+                  </a>
                 </div>
               </div>
             </l-popup>
@@ -253,12 +253,10 @@
             <l-popup>
               <div>
                 <span class="font-weight-bold mr-1">C-TRAN Stop ID:</span>
-
                 <span>{{item.props.stop_id}}</span>
               </div>
               <div>
                 <span class="font-weight-bold mr-1">C-TRAN Stop Name:</span>
-
                 <span>{{item.props.stop_name}}</span>
               </div>
             </l-popup>
@@ -303,7 +301,13 @@
             <l-popup>
               <div>
                 <span class="font-weight-bold mr-1">TriMet Stop ID:</span>
-                <span>{{item.props.stop_id}}</span>
+                <a
+                  :href="`https://trimet.org/ride/stop.html?stop_id=${item.props.stop_id}`"
+                  class="font-weight-bold secondary--text"
+                >
+                  {{item.props.stop_id}}
+                  <v-icon small color="secondary">launch</v-icon>
+                </a>
               </div>
               <div>
                 <span class="font-weight-bold mr-1">TriMet Stop Name:</span>

--- a/client/src/components/MainMap.vue
+++ b/client/src/components/MainMap.vue
@@ -733,10 +733,6 @@ export default {
     createTractLayer(feature, layer, tooltipDisplay, selectedTract) {
       return (feature, layer) => {
         layer.on("click", e => {
-          const southWest = e.target._bounds._southWest;
-          const northEast = e.target._bounds._northEast;
-          // eslint-disable-next-line
-          const tractBounds = L.latLngBounds(southWest, northEast);
           const {
             target: {
               feature: { properties },
@@ -744,10 +740,6 @@ export default {
           } = e;
           this.setTract(properties);
           this.setSelectedTab("map");
-          const polygonCenter = layer.getBounds().getCenter();
-          // eslint-disable-next-line
-          console.info("polygonCenter", polygonCenter);
-          this.$refs.map.fitBounds(tractBounds);
         });
 
         if (tooltipDisplay) {

--- a/client/src/components/SearchResults.vue
+++ b/client/src/components/SearchResults.vue
@@ -185,9 +185,7 @@
     </div>
     <div v-else class="primary--text">
       <h1 class="secondary--text my-3">Show Me the Vegetables!</h1>
-      <div
-        class="body-2"
-      >Enter a Portland Metro area address in the search bar at the top of the map and discover nearby sources of fresh produce.</div>
+      <div>Enter a Portland Metro area address in the search bar at the top of the map and discover nearby sources of fresh produce.</div>
     </div>
   </div>
 </template>

--- a/client/src/store/map.js
+++ b/client/src/store/map.js
@@ -40,7 +40,7 @@ const mutations = {
 
 const state = {
   center: [45.59, -122.6793],
-  displayStatusTooltip: true,
+  displayStatusTooltip: false,
   geosearchResult: null,
   userLatitude: null,
   userLongitude: null,


### PR DESCRIPTION
- eliminate zoom on tract selection
- make intro language less verbose
- remove small map marker icons to improve readability
- increase default body font size
- make styling in census tract profile consistent with styling in other tabs
- make button styles for clearing tract and search selections consistent
- add launch icon to popups where there are external links
- add link to Trimet stops from popup (C-Tran does not have pages for stops)